### PR TITLE
Restore design team pop-up behavior

### DIFF
--- a/src/pages/ProjectDetailPage.css
+++ b/src/pages/ProjectDetailPage.css
@@ -489,3 +489,92 @@
     font-size: 1.5rem;
   }
 }
+
+/* Design Team Modal Styles */
+.clickable-design-team {
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.clickable-design-team:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  transform: translateY(-1px);
+}
+
+.design-team-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 2rem;
+}
+
+.design-team-modal {
+  background: white;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+}
+
+.design-team-modal .modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem;
+  border-bottom: 1px solid #eee;
+}
+
+.design-team-modal .modal-header h2 {
+  margin: 0;
+  color: #333;
+  font-size: 1.5rem;
+}
+
+.design-team-modal .btn-close {
+  background: none;
+  border: none;
+  font-size: 2rem;
+  cursor: pointer;
+  color: #999;
+  padding: 0;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.3s ease;
+}
+
+.design-team-modal .btn-close:hover {
+  background: #f8f9fa;
+  color: #333;
+}
+
+.design-team-modal .modal-content {
+  padding: 1.5rem;
+}
+
+.design-team-info {
+  text-align: center;
+}
+
+.design-team-info p {
+  font-size: 1.2rem;
+  color: #333;
+  margin: 0;
+  padding: 1rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+  border-left: 4px solid #007bff;
+}

--- a/src/pages/ProjectDetailPage.js
+++ b/src/pages/ProjectDetailPage.js
@@ -15,6 +15,7 @@ const ProjectDetailPage = () => {
   const [project, setProject] = useState(null)
   const [hasAttemptedFetch, setHasAttemptedFetch] = useState(false)
   const [singleProjectLoading, setSingleProjectLoading] = useState(false)
+  const [showDesignTeamModal, setShowDesignTeamModal] = useState(false)
 
   useEffect(() => {
     // Fetch projects on mount if not already loaded
@@ -228,7 +229,9 @@ const ProjectDetailPage = () => {
             <div className="info-cell">{project.client || 'N/A'}</div>
             <div className="info-cell">{project.year || 'N/A'}</div>
             <div className="info-cell">{project.location || 'N/A'}</div>
-            <div className="info-cell">{project.designTeam || 'NAMAS Architecture'}</div>
+            <div className="info-cell clickable-design-team" onClick={() => setShowDesignTeamModal(true)}>
+              {project.designTeam || 'NAMAS Architecture'}
+            </div>
             <div className="info-cell">{project.status || 'N/A'}</div>
           </div>
         </div>
@@ -246,6 +249,26 @@ const ProjectDetailPage = () => {
           </div>
         )}
       </div>
+
+      {/* Design Team Modal */}
+      {showDesignTeamModal && (
+        <div className="design-team-modal-overlay" onClick={() => setShowDesignTeamModal(false)}>
+          <div className="design-team-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header">
+              <h2>Design Team</h2>
+              <button className="btn-close" onClick={() => setShowDesignTeamModal(false)}>
+                ×
+              </button>
+            </div>
+
+            <div className="modal-content">
+              <div className="design-team-info">
+                <p>{project.designTeam || 'NAMAS Architecture'}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Revert the design team display to a popup modal.

The user requested to restore the previous behavior where the design team information appeared in a popup.

---
<a href="https://cursor.com/background-agent?bcId=bc-e58e3e69-5e75-4980-ae80-27ece14f935f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e58e3e69-5e75-4980-ae80-27ece14f935f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>