### PR TITLE
Fix homepage slider redirect on mobile

### DIFF
--- a/src/components/HeroBannerSelfContained.js
+++ b/src/components/HeroBannerSelfContained.js
@@ -73,15 +73,18 @@ const HeroBannerSelfContained = () => {
     return () => clearInterval(interval)
   }, [featuredProjects.length])
 
-  const nextSlide = () => {
+  const nextSlide = (e) => {
+    e?.stopPropagation()
     setCurrentSlide(prev => (prev + 1) % featuredProjects.length)
   }
 
-  const prevSlide = () => {
+  const prevSlide = (e) => {
+    e?.stopPropagation()
     setCurrentSlide(prev => (prev - 1 + featuredProjects.length) % featuredProjects.length)
   }
 
-  const goToSlide = (index) => {
+  const goToSlide = (index, e) => {
+    e?.stopPropagation()
     setCurrentSlide(index)
   }
 
@@ -221,10 +224,10 @@ const HeroBannerSelfContained = () => {
         {/* Navigation arrows */}
         {featuredProjects.length > 1 && (
           <>
-            <button className="hero-arrow hero-arrow-left" onClick={prevSlide}>
+            <button className="hero-arrow hero-arrow-left" onClick={(e) => prevSlide(e)}>
               <ChevronLeft size={24} />
             </button>
-            <button className="hero-arrow hero-arrow-right" onClick={nextSlide}>
+            <button className="hero-arrow hero-arrow-right" onClick={(e) => nextSlide(e)}>
               <ChevronRight size={24} />
             </button>
           </>
@@ -237,7 +240,7 @@ const HeroBannerSelfContained = () => {
               <button
                 key={index}
                 className={`hero-indicator ${index === currentSlide ? 'active' : ''}`}
-                onClick={() => goToSlide(index)}
+                onClick={(e) => goToSlide(index, e)}
               />
             ))}
           </div>


### PR DESCRIPTION
Prevent slider navigation when clicking on slider control buttons by stopping event propagation.

The issue occurred because the slider control buttons (arrows and indicators) were nested within a clickable slide container. When these buttons were clicked, the event bubbled up to the parent slide, triggering its `onClick` handler which navigates to project details. This PR adds `e.stopPropagation()` to the slider control functions to prevent this unintended navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e668063a-2a04-4a56-8e31-cecfdcf1d678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e668063a-2a04-4a56-8e31-cecfdcf1d678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>