### PR TITLE
Add hero banner text to about pages

### DIFF
--- a/src/pages/AboutExteriorPage.css
+++ b/src/pages/AboutExteriorPage.css
@@ -62,6 +62,32 @@
   transform: translateX(-2px);
 }
 
+/* Hero Text Styling */
+.hero-text {
+  max-width: 600px;
+  color: white;
+  text-align: center;
+}
+
+.hero-title {
+  font-size: 4rem;
+  font-weight: 300;
+  line-height: 1.1;
+  margin-bottom: 1.5rem;
+  color: white;
+  text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.hero-subtitle {
+  font-size: clamp(1.25rem, 3vw, 2rem);
+  font-weight: 300;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  max-width: 600px;
+  opacity: 0.9;
+  line-height: 1.4;
+  margin-bottom: 0;
+}
+
 /* Content Section */
 .exterior-content {
   padding: 80px 0;

--- a/src/pages/AboutExteriorPage.js
+++ b/src/pages/AboutExteriorPage.js
@@ -15,6 +15,10 @@ function AboutExteriorPage() {
           <div className="hero-overlay"></div>
         </div>
         <div className="hero-content">
+          <div className="hero-text">
+            <h1 className="hero-title">Exterior Design</h1>
+            <p className="hero-subtitle">Where architecture meets nature in perfect harmony</p>
+          </div>
           <button className="back-button" onClick={() => navigate('/about')}>
             ← Back to About
           </button>

--- a/src/pages/AboutInteriorPage.css
+++ b/src/pages/AboutInteriorPage.css
@@ -62,6 +62,32 @@
   transform: translateX(-2px);
 }
 
+/* Hero Text Styling */
+.hero-text {
+  max-width: 600px;
+  color: white;
+  text-align: center;
+}
+
+.hero-title {
+  font-size: 4rem;
+  font-weight: 300;
+  line-height: 1.1;
+  margin-bottom: 1.5rem;
+  color: white;
+  text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.hero-subtitle {
+  font-size: clamp(1.25rem, 3vw, 2rem);
+  font-weight: 300;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  max-width: 600px;
+  opacity: 0.9;
+  line-height: 1.4;
+  margin-bottom: 0;
+}
+
 /* Content Section */
 .interior-content {
   padding: 80px 0;

--- a/src/pages/AboutInteriorPage.js
+++ b/src/pages/AboutInteriorPage.js
@@ -15,6 +15,10 @@ function AboutInteriorPage() {
           <div className="hero-overlay"></div>
         </div>
         <div className="hero-content">
+          <div className="hero-text">
+            <h1 className="hero-title">Interior Design</h1>
+            <p className="hero-subtitle">Bespoke, stylish, and functional environments</p>
+          </div>
           <button className="back-button" onClick={() => navigate('/about')}>
             ← Back to About
           </button>

--- a/src/pages/AboutPlanningPage.css
+++ b/src/pages/AboutPlanningPage.css
@@ -62,6 +62,32 @@
   transform: translateX(-2px);
 }
 
+/* Hero Text Styling */
+.hero-text {
+  max-width: 600px;
+  color: white;
+  text-align: center;
+}
+
+.hero-title {
+  font-size: 4rem;
+  font-weight: 300;
+  line-height: 1.1;
+  margin-bottom: 1.5rem;
+  color: white;
+  text-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.hero-subtitle {
+  font-size: clamp(1.25rem, 3vw, 2rem);
+  font-weight: 300;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  max-width: 600px;
+  opacity: 0.9;
+  line-height: 1.4;
+  margin-bottom: 0;
+}
+
 /* Content Section */
 .planning-content {
   padding: 80px 0;

--- a/src/pages/AboutPlanningPage.js
+++ b/src/pages/AboutPlanningPage.js
@@ -15,6 +15,10 @@ function AboutPlanningPage() {
           <div className="hero-overlay"></div>
         </div>
         <div className="hero-content">
+          <div className="hero-text">
+            <h1 className="hero-title">Planning Services</h1>
+            <p className="hero-subtitle">Strategic planning that transforms visions into reality</p>
+          </div>
           <button className="back-button" onClick={() => navigate('/about')}>
             ← Back to About
           </button>


### PR DESCRIPTION
Add hero banner text with respective titles and subtitles to the About Interior, About Exterior, and About Planning pages to match the homepage style.

---
<a href="https://cursor.com/background-agent?bcId=bc-83c6911d-70d2-4d5f-ae56-4bba1616fc24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-83c6911d-70d2-4d5f-ae56-4bba1616fc24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>