### PR TITLE
Start development server and compile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react-scripts": "5.0.1"
       },
       "devDependencies": {
+        "cross-env": "^7.0.3",
         "env-cmd": "^10.1.0"
       }
     },
@@ -5867,6 +5868,25 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "react-scripts": "5.0.1"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "env-cmd": "^10.1.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "cross-env NODE_OPTIONS=--no-deprecation react-scripts start",
     "build": "react-scripts build",
     "build:production": "env-cmd -f .env.production react-scripts build && cp public/.htaccess build/.htaccess",
     "build:cpanel": "npm run build:production && npm run optimize:cpanel",


### PR DESCRIPTION
Suppress webpack-dev-server deprecation warnings in `npm start`.

The `react-scripts@5.0.1` package, which is the latest version, still uses an older webpack-dev-server that emits deprecation warnings. These warnings are purely cosmetic and do not affect application functionality, but suppressing them cleans up the console output during development.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb991958-e024-4fe7-bf6b-27db390e4966">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb991958-e024-4fe7-bf6b-27db390e4966">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

