### PR TITLE
Fix design team form update issue

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -434,6 +434,7 @@ app.post("/api/projects", upload.array('images', 10), (req, res) => {
       location: req.body.location,
       year: req.body.year,
       client: req.body.client,
+      designTeam: req.body.designTeam, 
       featured: req.body.featured === 'true' || req.body.featured === true,
       status: req.body.status || 'completed',
       createdAt: new Date().toISOString(),
@@ -509,6 +510,7 @@ app.put("/api/projects/:id", upload.array('images', 10), (req, res) => {
       location: req.body.location || existingProject.location,
       year: req.body.year || existingProject.year,
       client: req.body.client || existingProject.client,
+      designTeam: req.body.designTeam || existingProject.designTeam,
       featured: req.body.featured !== undefined ? (req.body.featured === 'true' || req.body.featured === true) : existingProject.featured,
       status: req.body.status || existingProject.status,
       updatedAt: new Date().toISOString()


### PR DESCRIPTION
Persist `designTeam` field in project creation and update endpoints to ensure form updates are saved.

---
<a href="https://cursor.com/background-agent?bcId=bc-176c5da0-45aa-48f7-aaad-b23c4dc24d54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-176c5da0-45aa-48f7-aaad-b23c4dc24d54">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

