### PR TITLE
Align contact page text left

### DIFF
--- a/src/pages/ContactPage.css
+++ b/src/pages/ContactPage.css
@@ -117,6 +117,10 @@
   flex-shrink: 0;
 }
 
+.contact-text {
+  text-align: left;
+}
+
 .contact-text h4 {
   font-size: 1.2rem;
   font-weight: 600;


### PR DESCRIPTION
Left-align text next to icons on the contact page.

---
<a href="https://cursor.com/background-agent?bcId=bc-24326d8e-c549-4fd1-87de-82844eb9d405">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24326d8e-c549-4fd1-87de-82844eb9d405">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

