### PR TITLE
Create data folder in each build

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "scripts": {
     "start": "cross-env NODE_OPTIONS=--no-deprecation react-scripts start",
     "build": "react-scripts build",
-    "build:production": "env-cmd -f .env.production react-scripts build && cp public/.htaccess build/.htaccess",
+    "postbuild": "node scripts/copy-data-to-build.js",
+    "build:production": "env-cmd -f .env.production react-scripts build && node scripts/copy-data-to-build.js && cp public/.htaccess build/.htaccess",
     "build:cpanel": "npm run build:production && npm run optimize:cpanel",
     "optimize:cpanel": "echo 'Build completed for cPanel deployment. Upload the build folder contents to your cPanel public_html directory.'",
     "eject": "react-scripts eject"

--- a/scripts/copy-data-to-build.js
+++ b/scripts/copy-data-to-build.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+function ensureDir(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+}
+
+function copyFileSyncVerbose(src, dest) {
+  fs.copyFileSync(src, dest);
+  console.log(`Copied ${path.basename(src)} -> ${dest}`);
+}
+
+(function main() {
+  const projectRoot = path.resolve(__dirname, '..');
+  const sourceDir = path.join(projectRoot, 'server', 'data');
+  const targetDir = path.join(projectRoot, 'build', 'data');
+
+  if (!fs.existsSync(sourceDir)) {
+    console.warn(`No source data directory found at ${sourceDir}. Skipping data copy.`);
+    return;
+  }
+
+  ensureDir(targetDir);
+
+  const entries = fs.readdirSync(sourceDir, { withFileTypes: true });
+  entries.forEach((entry) => {
+    if (!entry.isFile()) return;
+    if (!entry.name.endsWith('.json')) return;
+
+    const src = path.join(sourceDir, entry.name);
+    const dest = path.join(targetDir, entry.name);
+    copyFileSyncVerbose(src, dest);
+  });
+
+  console.log(`Data copied to ${targetDir}`);
+})();


### PR DESCRIPTION
Add a post-build step to copy `server/data` JSON files into `build/data`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d11577c-f78d-4f23-897d-776a4c5ffba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d11577c-f78d-4f23-897d-776a4c5ffba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

