### PR TITLE
Ignore website data files from commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 /.pnp
 .pnp.js
 /server/data
+/server/uploads
+/server/backups
 
 # testing
 /coverage


### PR DESCRIPTION
Add `/server/uploads` and `/server/backups` to `.gitignore` to prevent dynamic website data from being committed.

---
<a href="https://cursor.com/background-agent?bcId=bc-13f1a2a7-35cc-4464-b56c-ed62552e9dd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-13f1a2a7-35cc-4464-b56c-ed62552e9dd4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

