### PR TITLE
Check hero banner image compression quality

### DIFF
--- a/src/components/ImageCropper.js
+++ b/src/components/ImageCropper.js
@@ -10,7 +10,8 @@ const ImageCropper = ({
   aspectRatio = null,
   circularCrop = false,
   minWidth = 100,
-  minHeight = 100
+  minHeight = 100,
+  originalFile = null
 }) => {
   const [crop, setCrop] = useState({
     unit: '%',
@@ -70,9 +71,13 @@ const ImageCropper = ({
     );
 
     return new Promise((resolve) => {
+      // Preserve original format and use higher quality
+      const originalType = originalFile?.type || 'image/jpeg';
+      const quality = originalType === 'image/png' ? undefined : 0.98; // PNG doesn't use quality
+      
       canvas.toBlob((blob) => {
         resolve(blob);
-      }, 'image/jpeg', 0.95);
+      }, originalType, quality);
     });
   }, []);
 
@@ -85,9 +90,11 @@ const ImageCropper = ({
       const croppedImageBlob = await getCroppedImg(imgRef.current, completedCrop);
       
       if (croppedImageBlob) {
-        // Create a File object from the blob
-        const croppedFile = new File([croppedImageBlob], 'cropped-image.jpg', {
-          type: 'image/jpeg'
+        // Create a File object from the blob, preserving original format
+        const originalType = originalFile?.type || 'image/jpeg';
+        const extension = originalType.split('/')[1] || 'jpg';
+        const croppedFile = new File([croppedImageBlob], `cropped-image.${extension}`, {
+          type: originalType
         });
         
         onCropComplete(croppedFile, URL.createObjectURL(croppedImageBlob));

--- a/src/components/ImageUploadWithCrop.js
+++ b/src/components/ImageUploadWithCrop.js
@@ -277,6 +277,7 @@ const ImageUploadWithCrop = ({
           onCropComplete={handleCropComplete}
           onCancel={handleCropCancel}
           aspectRatio={aspectRatio}
+          originalFile={currentCropFile.file}
         />
       )}
     </div>


### PR DESCRIPTION
Improve image quality during project creation uploads by preserving original formats and increasing JPEG quality.

The `ImageUploadWithCrop` component, used in project creation, was forcing all images through `ImageCropper.js`. This cropper converted all images to JPEG at 95% quality, causing quality loss, especially for PNGs which were converted from lossless to lossy. This PR ensures PNGs remain lossless and JPEGs are compressed less (98% quality).

---
<a href="https://cursor.com/background-agent?bcId=bc-3c9b0bd8-2360-4bbf-bb81-c87b1476eff9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c9b0bd8-2360-4bbf-bb81-c87b1476eff9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

